### PR TITLE
fix: remove superfluous comma causing TypeError in conda-frontend error message 

### DIFF
--- a/snakemake/deployment/conda.py
+++ b/snakemake/deployment/conda.py
@@ -729,7 +729,7 @@ class Conda:
                         "It is the recommended way of using Snakemake's conda integration. "
                         "It can be installed with `conda install -n base -c conda-forge mamba`. "
                         "If you still prefer to use conda, you can enforce that by setting "
-                        "`--conda-frontend conda`.",
+                        "`--conda-frontend conda`."
                     )
                 raise CreateCondaEnvironmentException(msg)
 


### PR DESCRIPTION
### Description
When running snakemake with micromamba a `CreateCondaEnvironmentException` should be raised (should it really? that is a different story... ;)

However, the code `msg += ("lorem ipsum",) tries to concatenate a str and tuple and causes a TypeError. 
Removing the trailing comma fixes this issue and the error message is successfully created and raised. 

### QC
<!-- Make sure that you can tick the boxes below. -->

I don't think these are relevant for this simple fix. 

* [ ] The PR contains a test case for the changes or the changes are already covered by an existing test case.
* [x] The documentation (`docs/`) is updated to reflect the changes or this is not necessary (e.g. if the change does neither modify the language nor the behavior or functionalities of Snakemake).
